### PR TITLE
Update appium-gulp-plugins

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,4 @@
 jenkins-gulper
-sample-android-project/build
-sample-android-windows-project/build
-sample-ios-project/build
+sample-android-project
+sample-android-windows-project
+sample-ios-project

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "setup.ps1"
   ],
   "dependencies": {
+    "@babel/runtime": "^7.0.0",
     "appium-support": "^2.5.0",
-    "babel-runtime": "=5.8.24",
     "bluebird": "^3.5.2",
     "lodash": "^4.17.10",
     "source-map-support": "^0.5.5",
@@ -44,7 +44,7 @@
     "clean": "rm -rf node_modules && rm -f package-lock.json && npm install",
     "build": "gulp transpile",
     "mocha": "mocha",
-    "prepublish": "gulp prepublish",
+    "prepare": "gulp prepublish",
     "test": "gulp once",
     "e2e-test": "gulp e2e-test",
     "watch": "gulp watch",
@@ -59,31 +59,22 @@
     "precommit-test"
   ],
   "devDependencies": {
-    "appium-gulp-plugins": "^2.2.2",
-    "babel-eslint": "^7.1.1",
+    "ajv": "^6.5.3",
+    "appium-gulp-plugins": "^3.1.0",
+    "babel-eslint": "^10.0.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
-    "eslint": "^3.18.0",
-    "eslint-config-appium": "^2.0.1",
-    "eslint-plugin-babel": "^3.3.0",
+    "eslint": "^5.2.0",
+    "eslint-config-appium": "^3.1.0",
     "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-mocha": "^4.7.0",
-    "eslint-plugin-promise": "^3.3.1",
-    "gulp": "^3.8.11",
+    "eslint-plugin-mocha": "^5.0.0",
+    "eslint-plugin-promise": "^4.0.0",
+    "gulp": "^4.0.0",
     "pre-commit": "^1.2.2",
     "sinon": "^6.3.4",
     "yargs": "^12.0.2"
   },
   "greenkeeper": {
-    "ignore": [
-      "babel-eslint",
-      "eslint",
-      "eslint-plugin-babel",
-      "eslint-plugin-import",
-      "eslint-plugin-mocha",
-      "eslint-plugin-promise",
-      "gulp",
-      "babel-runtime"
-    ]
+    "ignore": []
   }
 }

--- a/test/specs/android-tool-specs.js
+++ b/test/specs/android-tool-specs.js
@@ -10,7 +10,7 @@ chai.should();
 chai.use(chaiAsPromised);
 
 describe('android tools', function () {
-  before(async function () {
+  before(function () {
     let _spawn = utils.spawn;
     let _exec = utils.exec;
 
@@ -41,7 +41,7 @@ describe('android tools', function () {
     await androidTools.killAll(['ls', 'echo']);
   });
 
-  after(async function () {
+  after(function () {
     utils.spawn.restore();
     utils.exec.restore();
   });

--- a/test/specs/ios-tool-specs.js
+++ b/test/specs/ios-tool-specs.js
@@ -10,7 +10,7 @@ chai.should();
 chai.use(chaiAsPromised);
 
 describe('ios tools', function () {
-  before(async function () {
+  before(function () {
     let _exec = utils.exec;
     let _spawn = utils.spawn;
 
@@ -50,7 +50,7 @@ describe('ios tools', function () {
     await iosTools.killAll(['ls', 'echo']);
   });
 
-  after(async function () {
+  after(function () {
     utils.exec.restore();
     utils.spawn.restore();
   });


### PR DESCRIPTION
This PR does two main things:
1. Updates `eslint-config-appium` and fixes any linting errors.
1. Updated `appium-gulp-plugins` and moves to Babel 7 and Gulp 4.

See https://github.com/appium/appium-gulp-plugins/pull/35 for more details.